### PR TITLE
Build for Drill 1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.apache.drill.exec</groupId>
             <artifactId>drill-java-exec</artifactId>
-            <version>1.9.0</version>
+            <version>1.13.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes #1.

Probably, making the plugin version the same as Drill version is better because it clarifies which Drill version was used to build.

I confirmed this fix works with Drill 1.13.0.